### PR TITLE
fix: prevent duplicate symptom entries on stats fetch failure

### DIFF
--- a/src/pages/SymptomTrackerPage.jsx
+++ b/src/pages/SymptomTrackerPage.jsx
@@ -62,8 +62,6 @@ export default function SymptomTrackerPage() {
         notes,
       });
       setRecentLogs((prev) => [newLog, ...prev.slice(0, 4)]);
-      const { data: newStats } = await api.get('/api/symptoms/stats');
-      setStats(newStats);
       setSaved(true);
       setTimeout(() => setSaved(false), 3000);
       setSelected([]);
@@ -77,9 +75,15 @@ export default function SymptomTrackerPage() {
       const msg = err?.response?.data?.error || 'Failed to save. Please try again.';
       setSaveError(msg);
       toast.error(msg);
+      return;
     } finally {
       setIsSaving(false);
     }
+    // Best-effort stats refresh — failure here doesn't affect the confirmed save
+    try {
+      const { data: newStats } = await api.get('/api/symptoms/stats');
+      setStats(newStats);
+    } catch (_) {}
   };
 
   const formatDate = (d) =>


### PR DESCRIPTION
Found a weird bug where saving symptoms would sometimes flash a "Failed to save" error even though the entry actually saved fine. Turns out the save and the stats refresh were wrapped in the same `try/catch`; so if the stats call hiccuped after a successful save, it'd look like the whole thing failed. People would hit save again and end up with duplicate entries messing up their streaks and averages.

Split them into separate blocks so the save result is always reported correctly. Stats refresh now fails quietly in the background.