### PR TITLE
fix: row count using COUNT(*) OVER() window function

### DIFF
--- a/server/src/routes/symptoms.js
+++ b/server/src/routes/symptoms.js
@@ -27,17 +27,15 @@ router.get('/', async (req, res) => {
 
 // GET /api/symptoms/stats  — used by dashboard
 router.get('/stats', async (req, res) => {
-  // use COUNT(*) OVER()
-  const { rows } = await db.query(
+  // NOTE: COUNT(*) OVER() is computed before LIMIT,
+  // so total_count reflects the full matching row count (not just the 30 returned)
+  const { rows: logs } = await db.query(
     `SELECT date, severity, mood, energy, sleep, symptoms, COUNT(*) OVER() AS total_count FROM symptom_logs
      WHERE user_id = $1 ORDER BY date DESC LIMIT 30`,
     [req.user.id],
   );
 
-  const logs = rows;
   const total = rows.length? parseInt(rows[0].total_count, 10) : 0;
-  // console.log("rows: ", logs, "Total: ", rows);
-
 
   // streak: consecutive days from today
   let streak = 0;

--- a/server/src/routes/symptoms.js
+++ b/server/src/routes/symptoms.js
@@ -35,7 +35,7 @@ router.get('/stats', async (req, res) => {
     [req.user.id],
   );
 
-  const total = rows.length? parseInt(rows[0].total_count, 10) : 0;
+  const total = logs.length? parseInt(logs[0].total_count, 10) : 0;
 
   // streak: consecutive days from today
   let streak = 0;

--- a/server/src/routes/symptoms.js
+++ b/server/src/routes/symptoms.js
@@ -27,13 +27,17 @@ router.get('/', async (req, res) => {
 
 // GET /api/symptoms/stats  — used by dashboard
 router.get('/stats', async (req, res) => {
-  const { rows: logs } = await db.query(
-    `SELECT date, severity, mood, energy, sleep, symptoms FROM symptom_logs
+  // use COUNT(*) OVER()
+  const { rows } = await db.query(
+    `SELECT date, severity, mood, energy, sleep, symptoms, COUNT(*) OVER() AS total_count FROM symptom_logs
      WHERE user_id = $1 ORDER BY date DESC LIMIT 30`,
     [req.user.id],
   );
 
-  const total = logs.length;
+  const logs = rows;
+  const total = rows.length? parseInt(rows[0].total_count, 10) : 0;
+  // console.log("rows: ", logs, "Total: ", rows);
+
 
   // streak: consecutive days from today
   let streak = 0;


### PR DESCRIPTION
## Description: 
Window function (Count(*) Over()) counts rows but keeps all rows visible, adding the count to each row. so, here it will be better if we use a single query to calculate the rows. 

## Changes Made:
Added window function to get the correct row count.

closes #4 