### PR TITLE
Limit symptom logging to 2 entries per day

### DIFF
--- a/server/src/routes/symptoms.js
+++ b/server/src/routes/symptoms.js
@@ -85,6 +85,8 @@ router.get('/stats', async (req, res) => {
   res.json({ total, streak, thisWeek, avgSeverity, mostCommon, healthScore, lineData, barData });
 });
 
+const DAILY_LOG_LIMIT = 2;
+
 // POST /api/symptoms
 router.post('/',
   body('date').optional().isDate(),
@@ -99,10 +101,23 @@ router.post('/',
     if (!errors.isEmpty()) return res.status(400).json({ errors: errors.array() });
 
     const { date, symptoms, notes = '', severity, mood, energy, sleep } = req.body;
+    const logDate = date || new Date().toISOString().slice(0, 10);
+
+    const { rows: [{ count }] } = await db.query(
+      `SELECT COUNT(*) FROM symptom_logs WHERE user_id = $1 AND date = $2`,
+      [req.user.id, logDate],
+    );
+    if (parseInt(count) >= DAILY_LOG_LIMIT) {
+      return res.status(429).json({
+        error: `You can only log symptoms ${DAILY_LOG_LIMIT} times per day.`,
+        code: 'DAILY_LIMIT_REACHED',
+      });
+    }
+
     const { rows: [log] } = await db.query(
       `INSERT INTO symptom_logs (user_id, date, symptoms, notes, severity, mood, energy, sleep)
        VALUES ($1, $2, $3, $4, $5, $6, $7, $8) RETURNING *`,
-      [req.user.id, date || new Date().toISOString().slice(0, 10), JSON.stringify(symptoms), notes, severity, mood, energy, sleep],
+      [req.user.id, logDate, JSON.stringify(symptoms), notes, severity, mood, energy, sleep],
     );
     res.status(201).json(log);
   },

--- a/src/pages/SymptomTrackerPage.jsx
+++ b/src/pages/SymptomTrackerPage.jsx
@@ -30,11 +30,18 @@ export default function SymptomTrackerPage() {
   const [stats, setStats] = useState(null);
   const [loadingLogs, setLoadingLogs] = useState(true);
 
+  const DAILY_LIMIT = 2;
+  const todayStr = new Date().toISOString().slice(0, 10);
+  const todayCount = recentLogs.filter(
+    (l) => (l.date || '').slice(0, 10) === todayStr,
+  ).length;
+  const dailyLimitReached = todayCount >= DAILY_LIMIT;
+
   useEffect(() => {
     const load = async () => {
       try {
         const [logsRes, statsRes] = await Promise.all([
-          api.get('/api/symptoms?limit=5'),
+          api.get('/api/symptoms?limit=10'),
           api.get('/api/symptoms/stats'),
         ]);
         setRecentLogs(logsRes.data.logs);
@@ -162,19 +169,26 @@ export default function SymptomTrackerPage() {
                 />
               </div>
 
+              {dailyLimitReached && (
+                <div className="bg-amber-50 border border-amber-200 rounded-xl px-4 py-3 mb-4 text-center">
+                  <p className="text-amber-800 text-sm font-semibold mb-0.5">Daily limit reached</p>
+                  <p className="text-amber-700 text-xs">You've logged symptoms {DAILY_LIMIT} times today. Come back tomorrow to log again.</p>
+                </div>
+              )}
+
               {saveError && (
                 <p className="text-red-500 text-sm bg-red-50 border border-red-200 rounded-xl px-4 py-2 mb-4">{saveError}</p>
               )}
 
               <button
                 onClick={handleSave}
-                disabled={isSaving}
+                disabled={isSaving || dailyLimitReached}
                 className={`w-full flex items-center justify-center gap-2 py-3 rounded-xl font-semibold transition disabled:opacity-60 disabled:cursor-not-allowed ${
                   saved ? 'bg-green-500 text-white' : 'bg-[#FFF3CC] text-navy border border-[#E8D88A] hover:bg-[#FFE88A]'
                 }`}
               >
                 <Save size={16} />
-                {isSaving ? 'Saving…' : saved ? 'Entry Saved!' : "Save Today's Entry"}
+                {isSaving ? 'Saving…' : saved ? 'Entry Saved!' : dailyLimitReached ? 'Limit reached for today' : "Save Today's Entry"}
               </button>
             </div>
           </div>


### PR DESCRIPTION
## Summary

- **Server**: `POST /api/symptoms` now checks how many entries the user already has for the target date before inserting. Returns `429` with `DAILY_LIMIT_REACHED` if the count is ≥ 2, so the limit is enforced even if someone bypasses the UI.
- **Frontend**: Counts today's entries from the already-loaded log list. When the limit is reached the save button is disabled and a clear amber notice is shown — no extra API call needed.

## Test plan

- [ ] Log a symptom entry — should succeed
- [ ] Log a second entry on the same day — should succeed
- [ ] Attempt a third entry — button should be disabled with "Daily limit reached" message; a direct API call should return `429`
- [ ] Log on a different day (change system date or use the `date` field) — should succeed independently