### PR TITLE
feat: user profiles, avatar upload & settings page

### DIFF
--- a/server/migrate.sql
+++ b/server/migrate.sql
@@ -16,9 +16,14 @@ CREATE TABLE IF NOT EXISTS users (
   id              TEXT        PRIMARY KEY,  -- Firebase UID
   email           TEXT        UNIQUE NOT NULL,
   name            TEXT        NOT NULL,
+  bio             TEXT        NOT NULL DEFAULT '',
+  avatar_url      TEXT        NOT NULL DEFAULT '',
   onboarding_data JSONB       NOT NULL DEFAULT '{}',
   created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
+
+ALTER TABLE users ADD COLUMN IF NOT EXISTS bio        TEXT NOT NULL DEFAULT '';
+ALTER TABLE users ADD COLUMN IF NOT EXISTS avatar_url TEXT NOT NULL DEFAULT '';
 
 CREATE TABLE IF NOT EXISTS symptom_logs (
   id          UUID        PRIMARY KEY DEFAULT gen_random_uuid(),

--- a/server/src/routes/users.js
+++ b/server/src/routes/users.js
@@ -14,8 +14,8 @@ router.post('/sync', requireAuth, async (req, res) => {
     const { rows } = await db.query(
       `INSERT INTO users (id, email, name)
        VALUES ($1, $2, $3)
-       ON CONFLICT (id) DO UPDATE SET email = EXCLUDED.email, name = EXCLUDED.name
-       RETURNING id, email, name, onboarding_data`,
+       ON CONFLICT (id) DO UPDATE SET email = EXCLUDED.email
+       RETURNING id, email, name, bio, avatar_url, onboarding_data`,
       [req.user.id, email || req.user.email, name || req.user.name],
     );
     return res.json({ user: rows[0] });
@@ -24,6 +24,62 @@ router.post('/sync', requireAuth, async (req, res) => {
     return res.status(500).json({ error: 'Internal server error' });
   }
 });
+
+// GET /users/me — fetch current user's full profile
+router.get('/me', requireAuth, async (req, res) => {
+  try {
+    const { rows } = await db.query(
+      'SELECT id, email, name, bio, avatar_url, onboarding_data, created_at FROM users WHERE id = $1',
+      [req.user.id],
+    );
+    if (rows.length === 0) return res.status(404).json({ error: 'User not found' });
+    return res.json({ user: rows[0] });
+  } catch (err) {
+    console.error('get /users/me error:', err);
+    return res.status(500).json({ error: 'Internal server error' });
+  }
+});
+
+// PATCH /users/profile — update name, bio, avatar_url
+router.patch(
+  '/profile',
+  requireAuth,
+  [
+    body('name').optional().trim().notEmpty().withMessage('Name cannot be empty'),
+    body('bio').optional().trim(),
+    body('avatar_url').optional().trim(),
+  ],
+  async (req, res) => {
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) return res.status(400).json({ errors: errors.array() });
+
+    const { name, bio, avatar_url } = req.body;
+    const updates = [];
+    const values = [];
+    let idx = 1;
+
+    if (name !== undefined) { updates.push(`name = $${idx++}`); values.push(name); }
+    if (bio !== undefined) { updates.push(`bio = $${idx++}`); values.push(bio); }
+    if (avatar_url !== undefined) { updates.push(`avatar_url = $${idx++}`); values.push(avatar_url); }
+
+    if (updates.length === 0) return res.status(400).json({ error: 'No fields to update' });
+
+    values.push(req.user.id);
+
+    try {
+      const { rows } = await db.query(
+        `UPDATE users SET ${updates.join(', ')} WHERE id = $${idx}
+         RETURNING id, email, name, bio, avatar_url, onboarding_data`,
+        values,
+      );
+      if (rows.length === 0) return res.status(404).json({ error: 'User not found' });
+      return res.json({ user: rows[0] });
+    } catch (err) {
+      console.error('patch /users/profile error:', err);
+      return res.status(500).json({ error: 'Internal server error' });
+    }
+  },
+);
 
 // PATCH /users/me — saves onboarding data
 router.patch(
@@ -41,7 +97,7 @@ router.patch(
         `UPDATE users
          SET onboarding_data = onboarding_data || $1::jsonb
          WHERE id = $2
-         RETURNING id, email, name, onboarding_data`,
+         RETURNING id, email, name, bio, avatar_url, onboarding_data`,
         [JSON.stringify(onboarding_data), req.user.id],
       );
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -18,6 +18,7 @@ const ConsultationsPage   = lazy(() => import('./pages/ConsultationsPage'));
 const VerifyEmailPage     = lazy(() => import('./pages/VerifyEmailPage'));
 const PrivacyPolicyPage   = lazy(() => import('./pages/PrivacyPolicyPage'));
 const TermsOfServicePage  = lazy(() => import('./pages/TermsOfServicePage'));
+const SettingsPage        = lazy(() => import('./pages/SettingsPage'));
 const NotFoundPage        = lazy(() => import('./pages/NotFoundPage'));
 
 const PAGE_TITLES = {
@@ -32,6 +33,7 @@ const PAGE_TITLES = {
   '/education':       'Education — HarmoHelp',
   '/community':       'Community Hub — HarmoHelp',
   '/consultations':   'Book a Consultation — HarmoHelp',
+  '/settings':        'Settings — HarmoHelp',
   '/privacy':         'Privacy Policy — HarmoHelp',
   '/terms':           'Terms of Service — HarmoHelp',
 };
@@ -84,6 +86,7 @@ function AppRoutes() {
           <Route path="/education"       element={<ProtectedRoute element={<EducationPage />} />} />
           <Route path="/community"       element={<ProtectedRoute element={<CommunityPage />} />} />
           <Route path="/consultations"   element={<ProtectedRoute element={<ConsultationsPage />} />} />
+          <Route path="/settings"        element={<ProtectedRoute element={<SettingsPage />} />} />
           <Route path="*"               element={<NotFoundPage />} />
         </Routes>
       </Suspense>

--- a/src/components/DashboardNav.jsx
+++ b/src/components/DashboardNav.jsx
@@ -1,7 +1,8 @@
-import { Link, useLocation } from 'react-router-dom';
-import { Heart, Activity, BookOpen, Users, Calendar, Menu, X } from 'lucide-react';
-import { useState } from 'react';
+import { Link, useLocation, useNavigate } from 'react-router-dom';
+import { Heart, Activity, BookOpen, Users, Calendar, Menu, X, Settings, LogOut } from 'lucide-react';
+import { useState, useRef, useEffect } from 'react';
 import AIChatWidget from './AIChatWidget';
+import { useAuth } from '../context/AuthContext';
 
 const navItems = [
   { to: '/dashboard',       icon: Heart,     label: 'HarmoHelp' },
@@ -11,26 +12,95 @@ const navItems = [
   { to: '/consultations',   icon: Calendar,  label: 'Consultations' },
 ];
 
+function Avatar({ user, className = 'w-8 h-8' }) {
+  if (user?.avatar_url) {
+    return (
+      <img
+        src={user.avatar_url}
+        alt={user?.name}
+        className={`${className} rounded-full object-cover`}
+      />
+    );
+  }
+  return (
+    <div className={`${className} rounded-full bg-navy flex items-center justify-center text-white text-xs font-bold`}>
+      {user?.name?.charAt(0)?.toUpperCase() || '?'}
+    </div>
+  );
+}
+
 export default function DashboardNav() {
   const location = useLocation();
+  const navigate = useNavigate();
+  const { user, logout } = useAuth();
   const [open, setOpen] = useState(false);
+  const [dropdownOpen, setDropdownOpen] = useState(false);
+  const dropdownRef = useRef(null);
 
   const activeClass = (path) =>
     location.pathname === path
       ? 'bg-[#FFF3CC] text-navy font-semibold'
       : 'text-gray-600 hover:bg-gray-100';
 
+  useEffect(() => {
+    function handleClickOutside(e) {
+      if (dropdownRef.current && !dropdownRef.current.contains(e.target)) {
+        setDropdownOpen(false);
+      }
+    }
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, []);
+
+  const handleLogout = async () => {
+    setDropdownOpen(false);
+    await logout();
+    navigate('/');
+  };
+
   return (
     <>
       <AIChatWidget />
 
-      {/* Desktop nav — unchanged */}
-      <nav className="hidden sm:flex items-center justify-center gap-2 py-3 border-b border-gray-200 sticky top-0 bg-white z-10">
+      {/* Desktop nav */}
+      <nav className="hidden sm:flex relative items-center justify-center gap-2 py-3 border-b border-gray-200 sticky top-0 bg-white z-10">
         {navItems.map(({ to, icon: Icon, label }) => (
           <Link key={to} to={to} className={`flex items-center gap-2 px-4 py-2 rounded-full text-sm ${activeClass(to)}`}>
             <Icon size={16} /> {label}
           </Link>
         ))}
+
+        <div className="absolute right-4" ref={dropdownRef}>
+          <button
+            onClick={() => setDropdownOpen((v) => !v)}
+            className="flex items-center rounded-full hover:opacity-80 transition focus:outline-none"
+            aria-label="Profile menu"
+          >
+            <Avatar user={user} className="w-9 h-9" />
+          </button>
+
+          {dropdownOpen && (
+            <div className="absolute right-0 top-11 bg-white border border-gray-200 rounded-xl shadow-lg w-48 py-1 z-50">
+              <div className="px-4 py-2.5 border-b border-gray-100">
+                <p className="text-sm font-semibold text-navy truncate">{user?.name}</p>
+                <p className="text-xs text-gray-400 truncate">{user?.email}</p>
+              </div>
+              <Link
+                to="/settings"
+                onClick={() => setDropdownOpen(false)}
+                className="flex items-center gap-2 px-4 py-2.5 text-sm text-gray-700 hover:bg-gray-50 transition"
+              >
+                <Settings size={14} /> Settings
+              </Link>
+              <button
+                onClick={handleLogout}
+                className="w-full flex items-center gap-2 px-4 py-2.5 text-sm text-red-500 hover:bg-red-50 transition"
+              >
+                <LogOut size={14} /> Log out
+              </button>
+            </div>
+          )}
+        </div>
       </nav>
 
       {/* Mobile nav */}
@@ -39,13 +109,18 @@ export default function DashboardNav() {
           <Link to="/dashboard" className="flex items-center gap-2 text-navy font-bold text-sm">
             <Heart size={16} className="text-[#D4B83A]" /> HarmoHelp
           </Link>
-          <button
-            onClick={() => setOpen((v) => !v)}
-            className="p-2 rounded-xl text-gray-600 hover:bg-gray-100 transition"
-            aria-label={open ? 'Close menu' : 'Open menu'}
-          >
-            {open ? <X size={20} /> : <Menu size={20} />}
-          </button>
+          <div className="flex items-center gap-2">
+            <Link to="/settings" aria-label="Settings">
+              <Avatar user={user} className="w-8 h-8" />
+            </Link>
+            <button
+              onClick={() => setOpen((v) => !v)}
+              className="p-2 rounded-xl text-gray-600 hover:bg-gray-100 transition"
+              aria-label={open ? 'Close menu' : 'Open menu'}
+            >
+              {open ? <X size={20} /> : <Menu size={20} />}
+            </button>
+          </div>
         </div>
 
         {open && (

--- a/src/context/AuthContext.jsx
+++ b/src/context/AuthContext.jsx
@@ -17,6 +17,8 @@ function mapFirebaseUser(fbUser) {
     email: fbUser.email,
     name: fbUser.displayName || fbUser.email?.split('@')[0] || '',
     emailVerified: fbUser.emailVerified,
+    avatar_url: '',
+    bio: '',
   };
 }
 
@@ -35,6 +37,10 @@ export function AuthProvider({ children }) {
       if (fbUser.emailVerified) {
         try {
           await api.post('/users/sync', { name: mapped.name, email: mapped.email });
+          const { data } = await api.get('/users/me');
+          mapped.name = data.user.name;
+          mapped.bio = data.user.bio || '';
+          mapped.avatar_url = data.user.avatar_url || '';
         } catch (_) {}
       }
       setUser(mapped);
@@ -66,8 +72,14 @@ export function AuthProvider({ children }) {
     setUser(null);
   }, []);
 
+  const updateUserProfile = useCallback(async (fields) => {
+    const { data } = await api.patch('/users/profile', fields);
+    setUser((prev) => ({ ...prev, ...data.user }));
+    return data.user;
+  }, []);
+
   return (
-    <AuthContext.Provider value={{ user, isLoading, login, loginWithGoogle, signup, logout }}>
+    <AuthContext.Provider value={{ user, isLoading, login, loginWithGoogle, signup, logout, updateUserProfile }}>
       {children}
     </AuthContext.Provider>
   );

--- a/src/firebase.js
+++ b/src/firebase.js
@@ -1,5 +1,6 @@
 import { initializeApp } from 'firebase/app';
 import { getAuth } from 'firebase/auth';
+import { getStorage } from 'firebase/storage';
 import { getAnalytics, isSupported } from 'firebase/analytics';
 
 const firebaseConfig = {
@@ -12,8 +13,9 @@ const firebaseConfig = {
   measurementId:     import.meta.env.VITE_FIREBASE_MEASUREMENT_ID,
 };
 
-export const app  = initializeApp(firebaseConfig);
-export const auth = getAuth(app);
+export const app     = initializeApp(firebaseConfig);
+export const auth    = getAuth(app);
+export const storage = getStorage(app);
 
 // Analytics only runs in browser environments that support it
 export let analytics = null;

--- a/src/pages/SettingsPage.jsx
+++ b/src/pages/SettingsPage.jsx
@@ -1,0 +1,205 @@
+import { useState, useRef } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { User, Mail, Camera, LogOut, Save, ArrowLeft } from 'lucide-react';
+import { ref, uploadBytes, getDownloadURL } from 'firebase/storage';
+import toast from 'react-hot-toast';
+import DashboardNav from '../components/DashboardNav';
+import { useAuth } from '../context/AuthContext';
+import { storage } from '../firebase';
+
+export default function SettingsPage() {
+  const { user, logout, updateUserProfile } = useAuth();
+  const navigate = useNavigate();
+  const fileInputRef = useRef(null);
+
+  const [name, setName] = useState(user?.name || '');
+  const [bio, setBio] = useState(user?.bio || '');
+  const [avatarUploading, setAvatarUploading] = useState(false);
+  const [saving, setSaving] = useState(false);
+
+  const handleAvatarChange = async (e) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    if (!file.type.startsWith('image/')) {
+      toast.error('Please select an image file');
+      return;
+    }
+    if (file.size > 5 * 1024 * 1024) {
+      toast.error('Image must be under 5 MB');
+      return;
+    }
+
+    setAvatarUploading(true);
+    try {
+      const storageRef = ref(storage, `avatars/${user.id}`);
+      await uploadBytes(storageRef, file);
+      const url = await getDownloadURL(storageRef);
+      await updateUserProfile({ avatar_url: url });
+      toast.success('Profile picture updated');
+    } catch {
+      toast.error('Failed to upload image');
+    } finally {
+      setAvatarUploading(false);
+      e.target.value = '';
+    }
+  };
+
+  const handleSaveProfile = async () => {
+    if (!name.trim()) {
+      toast.error('Name cannot be empty');
+      return;
+    }
+    setSaving(true);
+    try {
+      await updateUserProfile({ name: name.trim(), bio: bio.trim() });
+      toast.success('Profile saved');
+    } catch {
+      toast.error('Failed to save profile');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleLogout = async () => {
+    await logout();
+    navigate('/');
+  };
+
+  return (
+    <div className="min-h-screen bg-white">
+      <DashboardNav />
+
+      <div className="max-w-2xl mx-auto px-4 sm:px-6 py-8">
+        <div className="flex items-center gap-3 mb-8">
+          <button
+            onClick={() => navigate(-1)}
+            className="p-2 rounded-xl hover:bg-gray-100 transition text-gray-500"
+            aria-label="Go back"
+          >
+            <ArrowLeft size={18} />
+          </button>
+          <div>
+            <h1 className="text-2xl font-black text-navy">Settings</h1>
+            <p className="text-gray-400 text-sm">Manage your account and preferences</p>
+          </div>
+        </div>
+
+        {/* Profile Picture */}
+        <section className="border border-gray-200 rounded-2xl p-6 mb-5">
+          <h2 className="text-base font-bold text-navy mb-4 flex items-center gap-2">
+            <Camera size={16} /> Profile Picture
+          </h2>
+          <div className="flex items-center gap-5">
+            <div className="relative shrink-0">
+              {user?.avatar_url ? (
+                <img
+                  src={user.avatar_url}
+                  alt={user.name}
+                  className="w-20 h-20 rounded-full object-cover border-2 border-gray-200"
+                />
+              ) : (
+                <div className="w-20 h-20 rounded-full bg-navy flex items-center justify-center text-white text-2xl font-bold border-2 border-gray-200">
+                  {user?.name?.charAt(0)?.toUpperCase() || '?'}
+                </div>
+              )}
+              {avatarUploading && (
+                <div className="absolute inset-0 rounded-full bg-black/40 flex items-center justify-center">
+                  <div className="w-5 h-5 border-2 border-white border-t-transparent rounded-full animate-spin" />
+                </div>
+              )}
+            </div>
+            <div>
+              <button
+                onClick={() => fileInputRef.current?.click()}
+                disabled={avatarUploading}
+                className="flex items-center gap-2 px-4 py-2 rounded-xl border border-gray-200 text-sm font-medium text-gray-700 hover:bg-gray-50 transition disabled:opacity-50"
+              >
+                <Camera size={14} /> {avatarUploading ? 'Uploading…' : 'Change photo'}
+              </button>
+              <p className="text-xs text-gray-400 mt-2">JPG, PNG or WebP · Max 5 MB</p>
+              <input
+                ref={fileInputRef}
+                type="file"
+                accept="image/*"
+                className="hidden"
+                onChange={handleAvatarChange}
+              />
+            </div>
+          </div>
+        </section>
+
+        {/* Personal Info */}
+        <section className="border border-gray-200 rounded-2xl p-6 mb-5">
+          <h2 className="text-base font-bold text-navy mb-4 flex items-center gap-2">
+            <User size={16} /> Personal Info
+          </h2>
+          <div className="flex flex-col gap-4">
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1.5">
+                Display name
+              </label>
+              <input
+                type="text"
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                className="w-full border border-gray-200 rounded-xl px-4 py-2.5 text-sm text-navy focus:outline-none focus:ring-2 focus:ring-[#D4B83A] focus:border-transparent"
+                placeholder="Your name"
+              />
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1.5">Bio</label>
+              <textarea
+                value={bio}
+                onChange={(e) => setBio(e.target.value)}
+                rows={3}
+                className="w-full border border-gray-200 rounded-xl px-4 py-2.5 text-sm text-navy focus:outline-none focus:ring-2 focus:ring-[#D4B83A] focus:border-transparent resize-none"
+                placeholder="A short bio about yourself…"
+              />
+            </div>
+            <div className="flex justify-end">
+              <button
+                onClick={handleSaveProfile}
+                disabled={saving}
+                className="flex items-center gap-2 px-5 py-2.5 bg-navy text-white rounded-xl text-sm font-semibold hover:bg-navy/90 transition disabled:opacity-50"
+              >
+                <Save size={14} /> {saving ? 'Saving…' : 'Save changes'}
+              </button>
+            </div>
+          </div>
+        </section>
+
+        {/* Account Info */}
+        <section className="border border-gray-200 rounded-2xl p-6 mb-5">
+          <h2 className="text-base font-bold text-navy mb-4 flex items-center gap-2">
+            <Mail size={16} /> Account
+          </h2>
+          <div>
+            <label className="block text-xs font-medium text-gray-400 mb-1.5">
+              Email address
+            </label>
+            <div className="flex items-center gap-2 border border-gray-200 rounded-xl px-4 py-2.5 bg-gray-50">
+              <span className="text-sm text-gray-500">{user?.email}</span>
+              <span className="ml-auto text-xs bg-green-100 text-green-700 px-2 py-0.5 rounded-full font-medium">
+                Verified
+              </span>
+            </div>
+          </div>
+        </section>
+
+        {/* Logout */}
+        <section className="border border-red-100 rounded-2xl p-6">
+          <h2 className="text-base font-bold text-navy mb-1">Log out</h2>
+          <p className="text-sm text-gray-400 mb-4">
+            You will be signed out and redirected to the home page.
+          </p>
+          <button
+            onClick={handleLogout}
+            className="flex items-center gap-2 px-5 py-2.5 bg-red-50 text-red-500 rounded-xl text-sm font-semibold hover:bg-red-100 transition border border-red-200"
+          >
+            <LogOut size={14} /> Log out
+          </button>
+        </section>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- **Profile avatar in navbar** — top-right corner on desktop shows the user's profile pic (or initials fallback) with a dropdown for Settings and Log out. Mobile header shows the avatar as a tap-to-settings shortcut.
- **Settings page (`/settings`)** — four sections: profile picture upload, personal info (name + bio), account (read-only email), and a logout button at the bottom that redirects to the home page.
- **Profile picture upload** — uses Firebase Storage (`avatars/{uid}`), 5 MB cap, image-only validation.
- **Backend** — new `GET /users/me` endpoint, new `PATCH /users/profile` endpoint (name, bio, avatar_url), `bio` and `avatar_url` columns added to the users table via `ALTER TABLE IF NOT EXISTS`. Also fixed the sync endpoint so a user-edited name in settings is not overwritten on next login.
- **AuthContext** — now hydrates `avatar_url` and `bio` from the DB on auth state change, and exposes `updateUserProfile` for in-app updates.

## Test plan

- [ ] Sign in — avatar/initials appear in the top-right of the nav on desktop and mobile
- [ ] Click avatar on desktop — dropdown shows name, email, Settings link, and Log out
- [ ] Settings → upload a profile picture — avatar updates across nav immediately
- [ ] Settings → change display name and bio → save — changes persist on page reload
- [ ] Settings → Log out — redirected to home page, session cleared
- [ ] Verify `/settings` redirects to `/login` when not authenticated
- [ ] Run `migrate.sql` on an existing DB — `ALTER TABLE IF NOT EXISTS` adds columns without dropping data