### PR TITLE
feat: FAQ and How to Use guide pages

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -19,6 +19,8 @@ const VerifyEmailPage     = lazy(() => import('./pages/VerifyEmailPage'));
 const PrivacyPolicyPage   = lazy(() => import('./pages/PrivacyPolicyPage'));
 const TermsOfServicePage  = lazy(() => import('./pages/TermsOfServicePage'));
 const SettingsPage        = lazy(() => import('./pages/SettingsPage'));
+const FAQPage             = lazy(() => import('./pages/FAQPage'));
+const GuidePage           = lazy(() => import('./pages/GuidePage'));
 const NotFoundPage        = lazy(() => import('./pages/NotFoundPage'));
 
 const PAGE_TITLES = {
@@ -34,6 +36,8 @@ const PAGE_TITLES = {
   '/community':       'Community Hub — HarmoHelp',
   '/consultations':   'Book a Consultation — HarmoHelp',
   '/settings':        'Settings — HarmoHelp',
+  '/faq':             'FAQ — HarmoHelp',
+  '/guide':           'How to Use — HarmoHelp',
   '/privacy':         'Privacy Policy — HarmoHelp',
   '/terms':           'Terms of Service — HarmoHelp',
 };
@@ -87,6 +91,8 @@ function AppRoutes() {
           <Route path="/community"       element={<ProtectedRoute element={<CommunityPage />} />} />
           <Route path="/consultations"   element={<ProtectedRoute element={<ConsultationsPage />} />} />
           <Route path="/settings"        element={<ProtectedRoute element={<SettingsPage />} />} />
+          <Route path="/faq"             element={<ProtectedRoute element={<FAQPage />} />} />
+          <Route path="/guide"           element={<ProtectedRoute element={<GuidePage />} />} />
           <Route path="*"               element={<NotFoundPage />} />
         </Routes>
       </Suspense>

--- a/src/pages/FAQPage.jsx
+++ b/src/pages/FAQPage.jsx
@@ -1,0 +1,200 @@
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { ChevronDown, ChevronUp, HelpCircle, ArrowLeft } from 'lucide-react';
+import DashboardNav from '../components/DashboardNav';
+
+const faqs = [
+  {
+    category: 'Getting Started',
+    items: [
+      {
+        q: 'What is HarmoHelp?',
+        a: 'HarmoHelp is a hormonal health and wellness platform designed to help you track symptoms, understand patterns in your health data, access educational resources, connect with a community, and book consultations with health experts — all in one place.',
+      },
+      {
+        q: 'Do I need to complete onboarding before using the app?',
+        a: 'Yes. The onboarding questionnaire helps HarmoHelp tailor your experience — including insights and recommendations — to your specific health profile. You can update your onboarding data any time through your profile settings.',
+      },
+      {
+        q: 'Is my email verification required?',
+        a: 'Yes. You must verify your email address before accessing the dashboard and any protected features. Check your inbox after sign-up and click the verification link. If you didn\'t receive it, you can request a new one from the verify email screen.',
+      },
+    ],
+  },
+  {
+    category: 'Symptom Tracking',
+    items: [
+      {
+        q: 'How do I log my symptoms?',
+        a: 'Go to Track Symptoms in the navigation bar. Select any symptoms you\'re experiencing from the checklist, then set your severity, mood, energy, and sleep scores using the sliders. Add optional notes, then hit Save Entry. Your log is saved and reflected on your dashboard immediately.',
+      },
+      {
+        q: 'How many times can I log symptoms in a day?',
+        a: 'You can log up to 2 entries per day. This limit exists to keep your data meaningful and avoid accidental duplicate entries. If you\'ve already logged twice today, the save button will be disabled until tomorrow.',
+      },
+      {
+        q: 'What do the severity, mood, energy, and sleep scores mean?',
+        a: 'All four scores use a 1–10 scale. Severity (1 = very mild symptoms, 10 = very severe), Mood (1 = very low, 10 = excellent), Energy (1 = completely drained, 10 = very energetic), Sleep (1 = very poor, 10 = excellent). Be consistent with how you rate these so your trend charts remain accurate.',
+      },
+      {
+        q: 'Can I delete a symptom log entry?',
+        a: 'Yes. In the Symptom Tracker page, your recent logs are listed at the bottom. Each entry has a delete option. Deleting an entry is permanent and will update your dashboard stats immediately.',
+      },
+    ],
+  },
+  {
+    category: 'Dashboard & Insights',
+    items: [
+      {
+        q: 'What is the streak counter on my dashboard?',
+        a: 'Your streak counts how many consecutive days you\'ve logged at least one symptom entry. It resets if you miss a day. Building a longer streak gives you richer trend data, which makes the insights and charts on your dashboard more accurate.',
+      },
+      {
+        q: 'How are the charts and trend lines calculated?',
+        a: 'The line chart shows your average severity over your last 7 logged days. The bar chart shows your weekly activity — how many entries you logged each day of the current week. All calculations use only your personal data and are never averaged with other users.',
+      },
+      {
+        q: 'Why does my total symptom count look different from what I expect?',
+        a: 'The total reflects the actual number of symptom log entries in the database — not the number of individual symptoms selected per entry. If you logged twice on one day, that counts as 2.',
+      },
+    ],
+  },
+  {
+    category: 'Community',
+    items: [
+      {
+        q: 'How do I post in the Community Hub?',
+        a: 'Navigate to Community in the nav bar. Click the New Post button, choose a category, write your title and body, then submit. Your post will appear in the feed immediately.',
+      },
+      {
+        q: 'Can I like or comment on other people\'s posts?',
+        a: 'Yes. Each post has a like button and a comment section. Click the heart icon to like a post and use the reply field to leave a comment. You can also unlike a post by clicking the heart again.',
+      },
+      {
+        q: 'Are community posts public to all users?',
+        a: 'Community posts are visible to all verified HarmoHelp users. They are not visible to the general public or to anyone who is not logged in.',
+      },
+    ],
+  },
+  {
+    category: 'Consultations & Shop',
+    items: [
+      {
+        q: 'How do I book a consultation?',
+        a: 'Go to Consultations in the nav bar. Choose your preferred consultation type (video, phone, or chat), pick an available date and time slot, add any notes for the expert, and confirm your booking. You\'ll see your upcoming bookings listed on the same page.',
+      },
+      {
+        q: 'How does payment work in the Shop?',
+        a: 'HarmoHelp uses Razorpay for secure payment processing. Add products to your cart, proceed to checkout, and you\'ll be taken through the Razorpay payment flow. Orders are recorded and visible in your order history on the dashboard.',
+      },
+    ],
+  },
+  {
+    category: 'Privacy & Account',
+    items: [
+      {
+        q: 'Is my health data private?',
+        a: 'Yes. Your symptom logs, scores, notes, and onboarding data are stored securely and are never shared with other users or third parties. Only you can see your personal health data.',
+      },
+      {
+        q: 'How do I update my name, bio, or profile picture?',
+        a: 'Go to Settings from the avatar menu in the top-right corner of the navigation bar. You can upload a new profile picture, change your display name, and update your bio from the Settings page.',
+      },
+      {
+        q: 'How do I log out?',
+        a: 'Click your avatar in the top-right corner of the nav bar and select Log out from the dropdown. You can also log out from the bottom of the Settings page. You\'ll be redirected to the home page.',
+      },
+    ],
+  },
+];
+
+function FAQItem({ q, a }) {
+  const [open, setOpen] = useState(false);
+  return (
+    <div className="border border-gray-200 rounded-xl overflow-hidden">
+      <button
+        onClick={() => setOpen((v) => !v)}
+        className="w-full flex items-center justify-between px-5 py-4 text-left hover:bg-gray-50 transition"
+      >
+        <span className="text-sm font-semibold text-navy pr-4">{q}</span>
+        {open ? (
+          <ChevronUp size={16} className="shrink-0 text-gray-400" />
+        ) : (
+          <ChevronDown size={16} className="shrink-0 text-gray-400" />
+        )}
+      </button>
+      {open && (
+        <div className="px-5 pb-4 text-sm text-gray-600 leading-relaxed border-t border-gray-100 pt-3">
+          {a}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default function FAQPage() {
+  const navigate = useNavigate();
+  const [search, setSearch] = useState('');
+
+  const filtered = faqs.map((section) => ({
+    ...section,
+    items: section.items.filter(
+      (item) =>
+        item.q.toLowerCase().includes(search.toLowerCase()) ||
+        item.a.toLowerCase().includes(search.toLowerCase()),
+    ),
+  })).filter((section) => section.items.length > 0);
+
+  return (
+    <div className="min-h-screen bg-white">
+      <DashboardNav />
+
+      <div className="max-w-2xl mx-auto px-4 sm:px-6 py-8">
+        <div className="flex items-center gap-3 mb-8">
+          <button
+            onClick={() => navigate(-1)}
+            className="p-2 rounded-xl hover:bg-gray-100 transition text-gray-500"
+            aria-label="Go back"
+          >
+            <ArrowLeft size={18} />
+          </button>
+          <div>
+            <h1 className="text-2xl font-black text-navy flex items-center gap-2">
+              <HelpCircle size={22} className="text-[#D4B83A]" /> Frequently Asked Questions
+            </h1>
+            <p className="text-gray-400 text-sm mt-0.5">Find answers to common questions about HarmoHelp</p>
+          </div>
+        </div>
+
+        <input
+          type="text"
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          placeholder="Search questions…"
+          className="w-full border border-gray-200 rounded-xl px-4 py-2.5 text-sm text-navy focus:outline-none focus:ring-2 focus:ring-[#D4B83A] focus:border-transparent mb-8"
+        />
+
+        {filtered.length === 0 ? (
+          <div className="text-center py-16 text-gray-400 text-sm">
+            No questions match your search.
+          </div>
+        ) : (
+          <div className="flex flex-col gap-8">
+            {filtered.map((section) => (
+              <div key={section.category}>
+                <h2 className="text-xs font-bold text-gray-400 uppercase tracking-widest mb-3">
+                  {section.category}
+                </h2>
+                <div className="flex flex-col gap-2">
+                  {section.items.map((item) => (
+                    <FAQItem key={item.q} q={item.q} a={item.a} />
+                  ))}
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/pages/GuidePage.jsx
+++ b/src/pages/GuidePage.jsx
@@ -1,0 +1,267 @@
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import {
+  ArrowLeft, BookOpen, LayoutDashboard, Activity,
+  TrendingUp, Users, Calendar, ShoppingBag, UserCircle,
+  CheckCircle,
+} from 'lucide-react';
+import DashboardNav from '../components/DashboardNav';
+
+const sections = [
+  {
+    id: 'getting-started',
+    icon: CheckCircle,
+    title: 'Getting Started',
+    intro: 'Set up your account and get familiar with the app in a few minutes.',
+    steps: [
+      {
+        heading: 'Create your account',
+        body: 'Sign up with your email address or Google account. After signing up with email, check your inbox for a verification link — you must verify before accessing the dashboard.',
+      },
+      {
+        heading: 'Complete onboarding',
+        body: 'Once verified, you\'ll be guided through a short onboarding questionnaire. This helps HarmoHelp personalise your experience — including insights and recommendations. Take your time and answer honestly; you can update your answers later from Settings.',
+      },
+      {
+        heading: 'Land on your dashboard',
+        body: 'After onboarding you\'ll arrive at the main dashboard. From here you can see your stats, recent activity, and quick links to every feature.',
+      },
+    ],
+  },
+  {
+    id: 'dashboard',
+    icon: LayoutDashboard,
+    title: 'Your Dashboard',
+    intro: 'The dashboard is your health at a glance.',
+    steps: [
+      {
+        heading: 'Stat cards',
+        body: 'Four cards at the top show your total symptoms logged, current streak, average severity, and recent order count. These update in real time as you log new entries.',
+      },
+      {
+        heading: 'Trend charts',
+        body: 'The line chart shows your average severity score across your last 7 logged days. The bar chart shows how many entries you logged on each day of the current week. Both charts are empty until you have at least one log.',
+      },
+      {
+        heading: 'Quick links',
+        body: 'Below the charts are shortcut cards for every major feature — Symptom Tracker, Education, Community, Consultations, and Shop. Click any card to jump straight there.',
+      },
+    ],
+  },
+  {
+    id: 'symptom-tracker',
+    icon: Activity,
+    title: 'Tracking Symptoms',
+    intro: 'The Symptom Tracker is the core of HarmoHelp. Log your daily health data to build a picture of your patterns over time.',
+    steps: [
+      {
+        heading: 'Select your symptoms',
+        body: 'Tap any symptom from the checklist to select it — selected symptoms are highlighted in navy. Common options include mood swings, fatigue, cramps, hot flashes, anxiety, and more. Select as many as apply.',
+      },
+      {
+        heading: 'Set your four scores',
+        body: 'Use the sliders to rate Severity (how intense your symptoms feel overall), Mood, Energy, and Sleep — each on a scale from 1 to 10. Try to use the same mental benchmark every day so your trend data stays meaningful.',
+      },
+      {
+        heading: 'Add optional notes',
+        body: 'The notes field is a free-text area for anything else worth recording — dietary changes, stress events, medication, exercise, or general observations. These notes stay private and are only visible to you.',
+      },
+      {
+        heading: 'Save your entry',
+        body: 'Click Save Entry. Your log is saved immediately and your dashboard stats update. You can log up to 2 entries per day. Once you\'ve hit the limit the save button is disabled until the next day.',
+      },
+      {
+        heading: 'Review and delete past logs',
+        body: 'Your recent entries are listed below the logging form. Each card shows the date, selected symptoms, and scores. Click the delete icon on any entry to remove it permanently.',
+      },
+    ],
+  },
+  {
+    id: 'insights',
+    icon: TrendingUp,
+    title: 'Reading Your Insights',
+    intro: 'HarmoHelp surfaces patterns in your logged data to help you understand your health trends.',
+    steps: [
+      {
+        heading: 'Symptom Insight Cards',
+        body: 'The dashboard and symptom tracker display AI-powered insight cards that highlight recurring symptoms, notable score changes, and patterns across your logs. These appear after you have a few entries and become more accurate over time.',
+      },
+      {
+        heading: 'Streak & consistency',
+        body: 'Consistent daily logging is the most important thing you can do to get useful insights. A longer streak means more data points, which means better pattern detection. Even on good days with no symptoms, logging a quick entry is valuable.',
+      },
+      {
+        heading: 'Interpreting score trends',
+        body: 'If your severity line chart is trending upward, your symptoms are worsening over time. If mood and energy are trending down together, that may indicate hormonal shifts worth discussing with a health professional. Use the charts as a conversation starter, not a diagnosis.',
+      },
+    ],
+  },
+  {
+    id: 'community',
+    icon: Users,
+    title: 'Community Hub',
+    intro: 'A safe space to share experiences, ask questions, and connect with others on similar health journeys.',
+    steps: [
+      {
+        heading: 'Browse the feed',
+        body: 'The Community feed shows posts from all users sorted by most recent. You can filter by category — such as General Discussion, Symptoms, Nutrition, or Mental Health — to find posts relevant to you.',
+      },
+      {
+        heading: 'Create a post',
+        body: 'Click New Post, choose a category, write a title and your message body, then submit. Your post appears in the feed immediately. Keep posts respectful and on-topic.',
+      },
+      {
+        heading: 'Like and comment',
+        body: 'Click the heart icon to like any post. Open a post to read and leave comments. You can unlike by clicking the heart again. Comments cannot currently be deleted once posted, so review before submitting.',
+      },
+    ],
+  },
+  {
+    id: 'consultations',
+    icon: Calendar,
+    title: 'Booking a Consultation',
+    intro: 'Connect with a health expert for a personalised one-on-one session.',
+    steps: [
+      {
+        heading: 'Choose a consultation type',
+        body: 'HarmoHelp offers three formats — Video Call, Phone Call, and Chat. Choose whichever you\'re most comfortable with.',
+      },
+      {
+        heading: 'Pick a date and time',
+        body: 'Select from the available time slots. Slots that are already booked will appear greyed out. Choose a slot that gives you enough time to prepare any questions or data you want to discuss.',
+      },
+      {
+        heading: 'Add notes for the expert',
+        body: 'Use the notes field to share context with your expert before the session — recent symptoms, concerns, or questions. This helps them make the most of your time together.',
+      },
+      {
+        heading: 'Confirm and track',
+        body: 'Click Confirm Booking. Your upcoming appointments will be listed on the Consultations page with their status. You can check back here to see whether your booking has been confirmed.',
+      },
+    ],
+  },
+  {
+    id: 'shop',
+    icon: ShoppingBag,
+    title: 'Shop',
+    intro: 'Browse and purchase health and wellness products curated for hormonal health.',
+    steps: [
+      {
+        heading: 'Browse products',
+        body: 'The shop lists supplements, wellness products, and health tools. Each product card shows the price, description, and stock availability. Use the category filters to narrow down what you\'re looking for.',
+      },
+      {
+        heading: 'Add to cart',
+        body: 'Click Add to Cart on any product. You can adjust quantities in the cart before checkout. The cart icon in the shop header shows your current item count.',
+      },
+      {
+        heading: 'Checkout',
+        body: 'Click Checkout in your cart. You\'ll be redirected to the Razorpay payment gateway for secure payment. After a successful payment, your order is recorded and visible in the Order History section of your dashboard.',
+      },
+    ],
+  },
+  {
+    id: 'profile',
+    icon: UserCircle,
+    title: 'Profile & Settings',
+    intro: 'Manage your personal information, appearance, and account preferences.',
+    steps: [
+      {
+        heading: 'Access Settings',
+        body: 'Click your avatar in the top-right corner of the navigation bar (or tap your avatar on mobile) to open the Settings page.',
+      },
+      {
+        heading: 'Update your profile picture',
+        body: 'In the Profile Picture section, click Change photo and select an image file from your device (JPG, PNG, or WebP, max 5 MB). The photo uploads to Firebase Storage and your avatar updates across the entire app immediately.',
+      },
+      {
+        heading: 'Edit your name and bio',
+        body: 'In the Personal Info section, update your display name and add a short bio. Click Save changes to apply. Your display name is shown in the nav dropdown and on your dashboard welcome message.',
+      },
+      {
+        heading: 'Log out',
+        body: 'Scroll to the bottom of the Settings page and click Log out. You can also log out from the avatar dropdown in the nav bar. Either way, you\'ll be signed out and redirected to the home page.',
+      },
+    ],
+  },
+];
+
+export default function GuidePage() {
+  const navigate = useNavigate();
+  const [active, setActive] = useState(sections[0].id);
+
+  const current = sections.find((s) => s.id === active);
+
+  return (
+    <div className="min-h-screen bg-white">
+      <DashboardNav />
+
+      <div className="max-w-5xl mx-auto px-4 sm:px-6 py-8">
+        <div className="flex items-center gap-3 mb-8">
+          <button
+            onClick={() => navigate(-1)}
+            className="p-2 rounded-xl hover:bg-gray-100 transition text-gray-500"
+            aria-label="Go back"
+          >
+            <ArrowLeft size={18} />
+          </button>
+          <div>
+            <h1 className="text-2xl font-black text-navy flex items-center gap-2">
+              <BookOpen size={22} className="text-[#D4B83A]" /> How to Use HarmoHelp
+            </h1>
+            <p className="text-gray-400 text-sm mt-0.5">A step-by-step guide to every feature</p>
+          </div>
+        </div>
+
+        <div className="flex flex-col sm:flex-row gap-6">
+          {/* Sidebar */}
+          <aside className="sm:w-52 shrink-0">
+            <nav className="flex sm:flex-col gap-1 overflow-x-auto sm:overflow-x-visible pb-2 sm:pb-0">
+              {sections.map(({ id, icon: Icon, title }) => (
+                <button
+                  key={id}
+                  onClick={() => setActive(id)}
+                  className={`flex items-center gap-2.5 px-3 py-2.5 rounded-xl text-sm font-medium whitespace-nowrap transition text-left ${
+                    active === id
+                      ? 'bg-[#FFF3CC] text-navy'
+                      : 'text-gray-500 hover:bg-gray-100'
+                  }`}
+                >
+                  <Icon size={15} className="shrink-0" />
+                  {title}
+                </button>
+              ))}
+            </nav>
+          </aside>
+
+          {/* Content */}
+          <main className="flex-1 min-w-0">
+            {current && (
+              <div>
+                <div className="flex items-center gap-3 mb-2">
+                  <current.icon size={20} className="text-[#D4B83A] shrink-0" />
+                  <h2 className="text-xl font-black text-navy">{current.title}</h2>
+                </div>
+                <p className="text-gray-500 text-sm mb-6">{current.intro}</p>
+
+                <div className="flex flex-col gap-5">
+                  {current.steps.map((step, i) => (
+                    <div key={step.heading} className="flex gap-4">
+                      <div className="shrink-0 w-7 h-7 rounded-full bg-[#FFF3CC] border border-[#E8D88A] flex items-center justify-center text-xs font-bold text-navy mt-0.5">
+                        {i + 1}
+                      </div>
+                      <div>
+                        <h3 className="text-sm font-bold text-navy mb-1">{step.heading}</h3>
+                        <p className="text-sm text-gray-600 leading-relaxed">{step.body}</p>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )}
+          </main>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/SettingsPage.jsx
+++ b/src/pages/SettingsPage.jsx
@@ -1,6 +1,6 @@
 import { useState, useRef } from 'react';
-import { useNavigate } from 'react-router-dom';
-import { User, Mail, Camera, LogOut, Save, ArrowLeft } from 'lucide-react';
+import { useNavigate, Link } from 'react-router-dom';
+import { User, Mail, Camera, LogOut, Save, ArrowLeft, HelpCircle, BookOpen, ChevronRight } from 'lucide-react';
 import { ref, uploadBytes, getDownloadURL } from 'firebase/storage';
 import toast from 'react-hot-toast';
 import DashboardNav from '../components/DashboardNav';
@@ -183,6 +183,41 @@ export default function SettingsPage() {
                 Verified
               </span>
             </div>
+          </div>
+        </section>
+
+        {/* Help & Resources */}
+        <section className="border border-gray-200 rounded-2xl p-6 mb-5">
+          <h2 className="text-base font-bold text-navy mb-4 flex items-center gap-2">
+            <HelpCircle size={16} /> Help &amp; Resources
+          </h2>
+          <div className="flex flex-col gap-2">
+            <Link
+              to="/guide"
+              className="flex items-center justify-between px-4 py-3 rounded-xl border border-gray-200 hover:bg-gray-50 transition"
+            >
+              <div className="flex items-center gap-3">
+                <BookOpen size={15} className="text-[#D4B83A]" />
+                <div>
+                  <p className="text-sm font-semibold text-navy">How to use HarmoHelp</p>
+                  <p className="text-xs text-gray-400">Step-by-step guide to every feature</p>
+                </div>
+              </div>
+              <ChevronRight size={15} className="text-gray-400" />
+            </Link>
+            <Link
+              to="/faq"
+              className="flex items-center justify-between px-4 py-3 rounded-xl border border-gray-200 hover:bg-gray-50 transition"
+            >
+              <div className="flex items-center gap-3">
+                <HelpCircle size={15} className="text-[#D4B83A]" />
+                <div>
+                  <p className="text-sm font-semibold text-navy">Frequently asked questions</p>
+                  <p className="text-xs text-gray-400">Quick answers to common questions</p>
+                </div>
+              </div>
+              <ChevronRight size={15} className="text-gray-400" />
+            </Link>
           </div>
         </section>
 


### PR DESCRIPTION
## Summary

- New **FAQ page** (`/faq`) — accordion Q&A across six categories: Getting Started, Symptom Tracking, Dashboard & Insights, Community, Consultations & Shop, and Privacy & Account. Includes a live search filter that matches against both questions and answers.
- New **How to Use guide** (`/guide`) — sidebar-navigated step-by-step walkthrough for all eight areas of the app: Getting Started, Dashboard, Symptom Tracker, Insights, Community, Consultations, Shop, and Profile & Settings. Sidebar collapses to a horizontal scroll on mobile.
- **Settings page** updated with a new Help & Resources section containing links to both pages with descriptions.
- Both pages are protected routes (require login), lazy-loaded, and have proper page titles.

## Test plan

- [ ] Settings → Help & Resources section is visible with both links
- [ ] Clicking "How to use HarmoHelp" navigates to `/guide`
- [ ] Guide sidebar lets you switch between all 8 sections; content updates correctly
- [ ] Guide sidebar scrolls horizontally on mobile without breaking layout
- [ ] Clicking "Frequently asked questions" navigates to `/faq`
- [ ] FAQ categories and all items expand/collapse correctly
- [ ] FAQ search filters results live; shows empty state when no match
- [ ] Back arrow on both pages navigates to previous page
- [ ] Both `/faq` and `/guide` redirect to `/login` when not authenticated